### PR TITLE
Rethink layout

### DIFF
--- a/app/components/ui/hoverbox/hoverbox.tsx
+++ b/app/components/ui/hoverbox/hoverbox.tsx
@@ -9,7 +9,6 @@ import {
 import {
   ButtonContext,
   Dialog,
-  OverlayArrow,
   PopoverContext,
   Provider,
 } from 'react-aria-components';
@@ -25,18 +24,6 @@ export function HoverBoxContent({ children }: { children: ReactNode }) {
 
   return (
     <Popover placement="left" isNonModal>
-      <OverlayArrow className="group">
-        <svg
-          role="img"
-          aria-label="Kleiner Pfeil"
-          width={12}
-          height={12}
-          viewBox="0 0 12 12"
-          className="group-placement-left:-rotate-90 block fill-popover stroke-1 stroke-border-default group-placement-bottom:rotate-180 group-placement-right:rotate-90"
-        >
-          <path d="M0 0 L6 6 L12 0" />
-        </svg>
-      </OverlayArrow>
       <Dialog className="focus:outline-none" aria-label="Aktuelle Tips">
         <div {...hoverProps}>{children}</div>
       </Dialog>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -62,7 +62,10 @@ export function Layout({ children }: { children: ReactNode }) {
   }, [revalidate, mode]);
 
   return (
-    <html lang="de" className={clsx(theme.colorScheme, 'overflow-clip')}>
+    <html
+      lang="de"
+      className={clsx(theme.colorScheme, 'bg-app text-app antialiased')}
+    >
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -70,7 +73,7 @@ export function Layout({ children }: { children: ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body className="h-dvh overflow-y-auto bg-app text-app">
+      <body>
         <UIProvider>
           {children}
           <Scripts />

--- a/app/routes/_foh+/($championship)+/index/_ranking.tsx
+++ b/app/routes/_foh+/($championship)+/index/_ranking.tsx
@@ -95,14 +95,11 @@ export default function RankingRoute() {
                         />
                       </Button>
                       <HoverBoxContent>
-                        <div className="grid w-[240px] grid-cols-[1fr_repeat(2,_auto)] pb-2 text-sm">
-                          <div className="border-default border-b py-2 pl-2">
-                            Spiel
+                        <div className="grid w-[248px] grid-cols-[1fr_repeat(2,_auto)] pb-2 text-sm">
+                          <div className="col-span-2 border-default border-b py-2 pl-2 font-semibold">
+                            Tipps von {player.user.name}
                           </div>
-                          <div className="border-default border-b p-2 text-center">
-                            Tipp
-                          </div>
-                          <div className="border-default border-b p-2 text-center">
+                          <div className="border-default border-b p-2 text-center font-semibold">
                             Pkt
                           </div>
                           {currentTips.map((m) => {

--- a/app/routes/manager+/_layout/_layout.tsx
+++ b/app/routes/manager+/_layout/_layout.tsx
@@ -18,11 +18,13 @@ export default function ManagerLayout() {
   const { championships } = useLoaderData<typeof loader>();
   return (
     <ChampionshipProvider championships={championships}>
-      <div className="grid h-dvh grid-cols-[auto_1fr]">
-        <ManagerNav className="w-0 overflow-y-auto border-default border-r bg-app-subtle shadow-medium md:flex md:w-52" />
-        <div className="grid grid-rows-[56px_1fr] overflow-y-auto px-2 md:px-4">
+      <div className="relative isolate flex min-h-svh w-full md:flex-col">
+        <div className="fixed inset-y-0 left-0 hidden w-52 border-default border-r bg-app-subtle shadow-medium md:flex">
+          <ManagerNav />
+        </div>
+        <div className="flex flex-1 flex-col md:pl-52">
           <ManagerHeader />
-          <div className="pt-2 pb-4">
+          <div className="p-2 pb-4 md:px-4">
             <Outlet />
           </div>
         </div>

--- a/app/routes/manager+/_layout/manager-header.tsx
+++ b/app/routes/manager+/_layout/manager-header.tsx
@@ -6,6 +6,7 @@ import {
   Modal,
   ModalOverlay,
 } from 'react-aria-components';
+import { ThemeMenu } from '#components/theme-menu';
 import { Button, Icon } from '#components/ui';
 import { usePageTitle } from '#utils/app/use-page-title';
 import { ManagerNav } from './manager-nav';
@@ -64,6 +65,9 @@ export function ManagerHeader() {
           </ModalOverlay>
         </DialogTrigger>
         <h1 className="font-medium text-xl">{pageTitle || 'Manager'}</h1>
+      </div>
+      <div className="flex gap-x-2">
+        <ThemeMenu />
       </div>
     </div>
   );

--- a/app/routes/manager+/_layout/manager-header.tsx
+++ b/app/routes/manager+/_layout/manager-header.tsx
@@ -32,7 +32,7 @@ export function ManagerHeader() {
   }, []);
 
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex items-center justify-between p-2 pt-3 md:px-4">
       <div className="flex items-center gap-x-2">
         <DialogTrigger
           isOpen={isOpen}
@@ -45,15 +45,15 @@ export function ManagerHeader() {
             className="fixed inset-0 z-20 backdrop-blur-sm"
             isDismissable
           >
-            <Modal className="flex h-dvh w-52 bg-popover">
+            <Modal className="relative flex h-svh max-w-64 bg-popover">
               <Dialog className="flex grow focus:outline-none">
                 {({ close }) => (
                   <>
-                    <ManagerNav className="grow overflow-y-auto" />
+                    <ManagerNav />
                     <Button
                       onPress={close}
                       variant="toolbar"
-                      className="absolute top-2 left-56 bg-popover"
+                      className="absolute top-2 right-2 bg-popover "
                     >
                       <Icon name="lucide/x" />
                     </Button>

--- a/app/routes/manager+/_layout/manager-header.tsx
+++ b/app/routes/manager+/_layout/manager-header.tsx
@@ -6,7 +6,6 @@ import {
   Modal,
   ModalOverlay,
 } from 'react-aria-components';
-import { ThemeMenu } from '#components/theme-menu';
 import { Button, Icon } from '#components/ui';
 import { usePageTitle } from '#utils/app/use-page-title';
 import { ManagerNav } from './manager-nav';
@@ -65,9 +64,6 @@ export function ManagerHeader() {
           </ModalOverlay>
         </DialogTrigger>
         <h1 className="font-medium text-xl">{pageTitle || 'Manager'}</h1>
-      </div>
-      <div className="flex gap-x-2">
-        <ThemeMenu />
       </div>
     </div>
   );

--- a/app/routes/manager+/_layout/manager-nav.tsx
+++ b/app/routes/manager+/_layout/manager-nav.tsx
@@ -1,4 +1,3 @@
-import clsx from 'clsx';
 import { Form } from 'react-aria-components';
 import { Logo } from '#components/logo';
 import { Icon, Link, NavLink } from '#components/ui';
@@ -8,7 +7,7 @@ export function ManagerNav({ className }: { className?: string }) {
   const { currentChampionship } = useChampionship();
 
   return (
-    <div className={clsx('flex flex-col', className)}>
+    <div className="flex grow flex-col overflow-y-auto">
       <div className="flex flex-col p-2">
         <Link href="/">
           <Logo />


### PR DESCRIPTION
- **fix: Remove theme-switch from header.**
- **fix: remove all layout related stylings from doc root.**
- **fix: Simplify layout. Resolves #139**
- **fix: Simplify the popovers. Resolves #129**
- **refactor: Bring back theme switch to manager header**
